### PR TITLE
feat: add sticky bottom navigation bar for mobile

### DIFF
--- a/InvoiceApp.Web/Pages/Shared/_Layout.cshtml
+++ b/InvoiceApp.Web/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+@{
+    var currentPage = ViewContext.RouteData.Values["page"]?.ToString() ?? "";
+}
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -45,5 +48,24 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
+
+    <nav class="bottom-nav d-flex d-md-none">
+        <a href="/" class="bottom-nav-item @(currentPage == "/Index" ? "active" : "")">
+            <i class="bi bi-house-fill"></i>
+            <span>Home</span>
+        </a>
+        <a href="/Invoices/History" class="bottom-nav-item @(currentPage.StartsWith("/Invoices") ? "active" : "")">
+            <i class="bi bi-file-text-fill"></i>
+            <span>Invoices</span>
+        </a>
+        <a href="/Rent" class="bottom-nav-item @(currentPage.StartsWith("/Rent") ? "active" : "")">
+            <i class="bi bi-house-door-fill"></i>
+            <span>Rent</span>
+        </a>
+        <a href="/Settings" class="bottom-nav-item @(currentPage.StartsWith("/Settings") ? "active" : "")">
+            <i class="bi bi-gear-fill"></i>
+            <span>Settings</span>
+        </a>
+    </nav>
 </body>
 </html>

--- a/InvoiceApp.Web/wwwroot/css/site.css
+++ b/InvoiceApp.Web/wwwroot/css/site.css
@@ -21,6 +21,50 @@ body {
   margin-bottom: 60px;
 }
 
+/* Bottom navigation bar */
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: #1a1a2e;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 1030;
+}
+
+.bottom-nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.55);
+  text-decoration: none;
+  font-size: 0.65rem;
+  gap: 3px;
+  min-height: 44px;
+  transition: color 0.15s;
+}
+
+.bottom-nav-item i {
+  font-size: 1.25rem;
+}
+
+.bottom-nav-item.active {
+  color: #e8c84a;
+}
+
+.bottom-nav-item:hover {
+  color: #fff;
+}
+
+@media (max-width: 767.98px) {
+  body {
+    padding-bottom: 68px;
+  }
+}
+
 /* Mobile touch targets */
 @media (max-width: 767.98px) {
   .navbar-nav .nav-link {


### PR DESCRIPTION
## Summary
- Fixed bottom nav bar with 4 tabs: Home, Invoices, Rent, Settings
- Visible only on mobile (hidden at md+ breakpoint via d-md-none)
- Active tab highlights in gold using current Razor Page route detection
- Matches app color scheme (dark background #1a1a2e, gold active #e8c84a)
- Body padding-bottom added on mobile so content never hides behind the nav

## Test plan
- [ ] On mobile viewport — bottom nav appears with 4 tabs
- [ ] On desktop — bottom nav is hidden
- [ ] Navigate to each section — correct tab highlights as active
- [ ] Scroll to bottom of long pages — content not obscured by nav
- [ ] Top hamburger menu still works as before

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)