### PR TITLE
feat: global error handling — friendly error page + DB error log + admin viewer

### DIFF
--- a/InvoiceApp.Core/Entities/ErrorLog.cs
+++ b/InvoiceApp.Core/Entities/ErrorLog.cs
@@ -1,0 +1,12 @@
+namespace InvoiceApp.Core.Entities;
+
+public class ErrorLog
+{
+    public int Id { get; set; }
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public string RequestPath { get; set; } = string.Empty;
+    public string RequestId { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? StackTrace { get; set; }
+    public string? InnerMessage { get; set; }
+}

--- a/InvoiceApp.Infrastructure/Data/AppDbContext.cs
+++ b/InvoiceApp.Infrastructure/Data/AppDbContext.cs
@@ -14,6 +14,7 @@ public class AppDbContext : DbContext
     public DbSet<SavedRate> SavedRates => Set<SavedRate>();
     public DbSet<Room> Rooms => Set<Room>();
     public DbSet<RentPayment> RentPayments => Set<RentPayment>();
+    public DbSet<ErrorLog> ErrorLogs => Set<ErrorLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/InvoiceApp.Infrastructure/Migrations/20260419110327_AddErrorLog.Designer.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419110327_AddErrorLog.Designer.cs
@@ -4,6 +4,7 @@ using InvoiceApp.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace InvoiceApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419110327_AddErrorLog")]
+    partial class AddErrorLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/InvoiceApp.Infrastructure/Migrations/20260419110327_AddErrorLog.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419110327_AddErrorLog.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InvoiceApp.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddErrorLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ErrorLogs",
+                schema: "blacktech",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RequestPath = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RequestId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    StackTrace = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    InnerMessage = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ErrorLogs", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ErrorLogs",
+                schema: "blacktech");
+        }
+    }
+}

--- a/InvoiceApp.Web/Pages/Admin/ErrorLog.cshtml
+++ b/InvoiceApp.Web/Pages/Admin/ErrorLog.cshtml
@@ -1,0 +1,94 @@
+@page
+@model InvoiceApp.Web.Pages.Admin.ErrorLogModel
+@{
+    ViewData["Title"] = "Error Log";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="fw-bold mb-0">
+        <i class="bi bi-journal-text text-danger"></i> Error Log
+        @if (Model.TotalCount > 0)
+        {
+            <span class="badge bg-danger ms-1">@Model.TotalCount</span>
+        }
+    </h5>
+    @if (Model.Errors.Any())
+    {
+        <form method="post" asp-page-handler="Clear"
+              onsubmit="return confirm('Clear all @Model.TotalCount error entries?')">
+            <button class="btn btn-sm btn-outline-danger">
+                <i class="bi bi-trash"></i> Clear All
+            </button>
+        </form>
+    }
+</div>
+
+@if (!Model.Errors.Any())
+{
+    <div class="text-center text-muted py-5">
+        <i class="bi bi-check-circle fs-1 text-success"></i>
+        <p class="mt-2">No errors logged.</p>
+    </div>
+}
+else
+{
+    @foreach (var error in Model.Errors)
+    {
+        <div class="card mb-3 border-danger border-opacity-25">
+            <div class="card-body py-2 px-3">
+                <div class="d-flex justify-content-between align-items-start gap-2">
+                    <div class="flex-grow-1 overflow-hidden">
+                        <div class="fw-semibold text-danger text-truncate">@error.Message</div>
+                        <div class="text-muted small">
+                            @error.Timestamp.ToLocalTime().ToString("dd MMM yyyy HH:mm:ss")
+                            &nbsp;&mdash;&nbsp;
+                            <code class="small">@error.RequestPath</code>
+                        </div>
+                        @if (!string.IsNullOrEmpty(error.InnerMessage))
+                        {
+                            <div class="text-muted small mt-1">Inner: @error.InnerMessage</div>
+                        }
+                        @if (!string.IsNullOrEmpty(error.StackTrace))
+                        {
+                            <details class="mt-2">
+                                <summary class="text-muted small" style="cursor:pointer">Stack trace</summary>
+                                <pre class="mt-1 p-2 bg-light rounded small" style="white-space:pre-wrap;word-break:break-all;max-height:200px;overflow-y:auto">@error.StackTrace</pre>
+                            </details>
+                        }
+                        <div class="text-muted" style="font-size:0.7rem">ID: @error.RequestId</div>
+                    </div>
+                    <form method="post" asp-page-handler="Delete" asp-route-id="@error.Id" style="flex-shrink:0">
+                        <button class="btn btn-sm btn-outline-danger"
+                                onclick="return confirm('Delete this entry?')">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    }
+
+    @if (Model.TotalPages > 1)
+    {
+        <nav class="mt-3">
+            <ul class="pagination justify-content-center flex-wrap">
+                <li class="page-item @(Model.PageNumber == 1 ? "disabled" : "")">
+                    <a class="page-link" href="?pageNumber=@(Model.PageNumber - 1)">
+                        <i class="bi bi-chevron-left"></i>
+                    </a>
+                </li>
+                @for (int i = 1; i <= Model.TotalPages; i++)
+                {
+                    <li class="page-item @(i == Model.PageNumber ? "active" : "")">
+                        <a class="page-link" href="?pageNumber=@i">@i</a>
+                    </li>
+                }
+                <li class="page-item @(Model.PageNumber == Model.TotalPages ? "disabled" : "")">
+                    <a class="page-link" href="?pageNumber=@(Model.PageNumber + 1)">
+                        <i class="bi bi-chevron-right"></i>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    }
+}

--- a/InvoiceApp.Web/Pages/Admin/ErrorLog.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Admin/ErrorLog.cshtml.cs
@@ -1,0 +1,50 @@
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace InvoiceApp.Web.Pages.Admin;
+
+public class ErrorLogModel : PageModel
+{
+    private readonly AppDbContext _db;
+
+    public ErrorLogModel(AppDbContext db) => _db = db;
+
+    public List<ErrorLog> Errors { get; private set; } = new();
+    public int TotalCount { get; private set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int PageNumber { get; set; } = 1;
+
+    public int PageSize => 20;
+    public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+    public async Task OnGetAsync()
+    {
+        TotalCount = await _db.ErrorLogs.CountAsync();
+        Errors = await _db.ErrorLogs
+            .OrderByDescending(e => e.Timestamp)
+            .Skip((PageNumber - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(int id)
+    {
+        var entry = await _db.ErrorLogs.FindAsync(id);
+        if (entry != null)
+        {
+            _db.ErrorLogs.Remove(entry);
+            await _db.SaveChangesAsync();
+        }
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostClearAsync()
+    {
+        await _db.ErrorLogs.ExecuteDeleteAsync();
+        return RedirectToPage();
+    }
+}

--- a/InvoiceApp.Web/Pages/Error.cshtml
+++ b/InvoiceApp.Web/Pages/Error.cshtml
@@ -1,26 +1,32 @@
-﻿@page
+@page
 @model ErrorModel
 @{
-    ViewData["Title"] = "Error";
+    ViewData["Title"] = "Something went wrong";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
-
-@if (Model.ShowRequestId)
-{
-    <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+<div class="text-center py-5">
+    <i class="bi bi-exclamation-triangle-fill text-danger" style="font-size:3rem"></i>
+    <h4 class="fw-bold mt-3 mb-1">Something went wrong</h4>
+    <p class="text-muted mb-4">
+        An unexpected error occurred. The issue has been logged and will be looked into.
     </p>
-}
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+    @if (Model.ShowRequestId)
+    {
+        <p class="text-muted small mb-4">
+            Reference: <code>@Model.RequestId</code>
+        </p>
+    }
+
+    <div class="d-flex gap-2 justify-content-center flex-wrap">
+        <a href="/" class="btn btn-primary">
+            <i class="bi bi-house"></i> Go to Dashboard
+        </a>
+        <button onclick="history.back()" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left"></i> Go Back
+        </button>
+        <a href="/Admin/ErrorLog" class="btn btn-outline-danger btn-sm">
+            <i class="bi bi-journal-text"></i> View Error Log
+        </a>
+    </div>
+</div>

--- a/InvoiceApp.Web/Pages/Error.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Error.cshtml.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics;
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Infrastructure.Data;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -8,20 +11,44 @@ namespace InvoiceApp.Web.Pages;
 [IgnoreAntiforgeryToken]
 public class ErrorModel : PageModel
 {
-    public string? RequestId { get; set; }
-
-    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
+    private readonly AppDbContext _db;
     private readonly ILogger<ErrorModel> _logger;
 
-    public ErrorModel(ILogger<ErrorModel> logger)
+    public string RequestId { get; private set; } = string.Empty;
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    public ErrorModel(AppDbContext db, ILogger<ErrorModel> logger)
     {
+        _db = db;
         _logger = logger;
     }
 
-    public void OnGet()
+    public async Task OnGetAsync()
     {
         RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+
+        var feature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
+        if (feature?.Error is not { } ex) return;
+
+        _logger.LogError(ex, "Unhandled exception on {Path}", feature.Path);
+
+        try
+        {
+            _db.ErrorLogs.Add(new ErrorLog
+            {
+                Timestamp   = DateTime.UtcNow,
+                RequestPath = feature.Path ?? string.Empty,
+                RequestId   = RequestId,
+                Message     = ex.Message,
+                StackTrace  = ex.StackTrace,
+                InnerMessage = ex.InnerException?.Message
+            });
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception dbEx)
+        {
+            // Never let a logging failure replace the original error page
+            _logger.LogWarning(dbEx, "Failed to persist error log to database");
+        }
     }
 }
-


### PR DESCRIPTION
## Problem
Unhandled exceptions showed an unstyled page with developer instructions visible to end users. No error history was kept anywhere.

## Changes

### ErrorLog entity + migration
New `ErrorLog` table (`blacktech` schema) with: `Id`, `Timestamp`, `RequestPath`, `RequestId`, `Message`, `StackTrace`, `InnerMessage`. Migration auto-applied on startup.

### Error page (improved)
- Friendly Bootstrap-styled message using the app layout
- Shows a reference number (`RequestId`) the user can quote
- Actions: Go to Dashboard / Go Back / View Error Log

### Error.cshtml.cs (logging)
- Reads the actual exception via `IExceptionHandlerPathFeature`
- Saves to `ErrorLog` table on every unhandled error
- DB failure is caught and logged as a warning — a broken DB connection never replaces the error page itself

### /Admin/ErrorLog (new page)
- Paginated list of all logged errors (20 per page)
- Shows timestamp, request path, message, inner exception, collapsible stack trace
- Per-entry delete and Clear All actions
- Linked from the error page itself

## Test plan
- [ ] Trigger an error (e.g. navigate to a page that throws) — see friendly error page
- [ ] Check `/Admin/ErrorLog` — entry appears with correct path, message, stack trace
- [ ] Delete a single entry — removed from list
- [ ] Clear All — table emptied
- [ ] All 25 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)