### PR TITLE
fix: invoice print — full-width table and unclipped stamp

### DIFF
--- a/InvoiceApp.Web/Pages/Invoices/Preview.cshtml
+++ b/InvoiceApp.Web/Pages/Invoices/Preview.cshtml
@@ -290,8 +290,32 @@
         /* Print */
         @@media print {
             body { background: white; }
-            .invoice-wrap { box-shadow: none; margin: 0; border-radius: 0; }
+
+            .invoice-wrap {
+                box-shadow: none;
+                margin: 0;
+                border-radius: 0;
+                max-width: 100%;          /* fill full paper width */
+                overflow: visible;        /* allow rotated stamp corners to show */
+                break-inside: avoid;
+            }
+
             .no-print { display: none !important; }
+
+            /* Restore all table columns — mobile CSS hides cols 2 & 3
+               but print can render at <600px CSS width (Firefox ~595px) */
+            .items-table thead th,
+            .items-table tbody td { display: table-cell !important; }
+
+            /* Restore desktop padding that mobile CSS overrides */
+            .items-section  { padding: 0 32px 24px !important; }
+            .banking-section { margin: 0 32px 32px !important; }
+            .notes-section   { margin: 0 32px 20px !important; }
+
+            /* Lift stamp higher so the rotated bottom corners
+               (rotate(-12deg) extends ~12px below the div's box) sit
+               clear of any page-margin cut */
+            .invoice-stamp { bottom: 100px; }
         }
 
         /* Mobile */


### PR DESCRIPTION
## Problems fixed

### 1. Table columns hidden / short on print
`@media (max-width: 600px)` hides the Qty and Unit columns and reduces section padding. Firefox renders print layout at ~595px CSS width, which triggers the mobile breakpoint during printing. Chrome/Edge are less affected but still benefit from the explicit reset.

**Fix:** `@media print` now explicitly restores all table columns (`display: table-cell !important`) and desktop section padding.

### 2. Stamp cut at bottom
`.invoice-wrap` has `overflow: hidden` which clips the rotated stamp. The `rotate(-12deg)` transform causes the stamp's corners to extend ~12px below its 130×130px box boundary — `overflow: hidden` clips that.

**Fix:** `overflow: visible` in print media. Stamp also lifted from `bottom: 80px` to `bottom: 100px` so rotated corners clear any paper-margin page cut.

### 3. Invoice narrower than paper
`max-width: 780px` was not overridden in print, leaving the invoice card narrower than the printed page on some paper sizes.

**Fix:** `max-width: 100%` added in print.

## Test plan
- [ ] Open an invoice → Preview → Print (or Ctrl+P)
- [ ] All 5 table columns visible on the print preview
- [ ] Invoice fills full paper width
- [ ] Stamp circle and invoice number fully visible, not cut
- [ ] Screen view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)