### PR TITLE
feat: add property/agent branding to rent receipts with print preview

### DIFF
--- a/InvoiceApp.Core/Entities/RentSettings.cs
+++ b/InvoiceApp.Core/Entities/RentSettings.cs
@@ -1,0 +1,13 @@
+namespace InvoiceApp.Core.Entities;
+
+public class RentSettings
+{
+    public int Id { get; set; }
+    public string PropertyName { get; set; } = string.Empty;
+    public string AgentName { get; set; } = string.Empty;
+    public string? AgentPhone { get; set; }
+    public string? AddressLine1 { get; set; }
+    public string? AddressLine2 { get; set; }
+    public string? City { get; set; }
+    public string? PostalCode { get; set; }
+}

--- a/InvoiceApp.Infrastructure/Data/AppDbContext.cs
+++ b/InvoiceApp.Infrastructure/Data/AppDbContext.cs
@@ -14,6 +14,7 @@ public class AppDbContext : DbContext
     public DbSet<SavedRate> SavedRates => Set<SavedRate>();
     public DbSet<Room> Rooms => Set<Room>();
     public DbSet<RentPayment> RentPayments => Set<RentPayment>();
+    public DbSet<RentSettings> RentSettings => Set<RentSettings>();
     public DbSet<ErrorLog> ErrorLogs => Set<ErrorLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/InvoiceApp.Infrastructure/Migrations/20260419120208_AddRentSettings.Designer.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419120208_AddRentSettings.Designer.cs
@@ -4,6 +4,7 @@ using InvoiceApp.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace InvoiceApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419120208_AddRentSettings")]
+    partial class AddRentSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/InvoiceApp.Infrastructure/Migrations/20260419120208_AddRentSettings.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419120208_AddRentSettings.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InvoiceApp.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRentSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RentSettings",
+                schema: "blacktech",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PropertyName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AgentName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AgentPhone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AddressLine1 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AddressLine2 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RentSettings", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RentSettings",
+                schema: "blacktech");
+        }
+    }
+}

--- a/InvoiceApp.Infrastructure/Services/RentReceiptPdfService.cs
+++ b/InvoiceApp.Infrastructure/Services/RentReceiptPdfService.cs
@@ -13,9 +13,10 @@ public class RentReceiptPdfService
     private const string Muted = "#888888";
     private const string Body  = "#333333";
 
-    public byte[] Generate(RentPayment payment, CompanySettings? company, BankingDetails? banking)
+    public byte[] Generate(RentPayment payment, RentSettings? rentSettings, BankingDetails? banking)
     {
-        var companyName = company?.Name ?? string.Empty;
+        var propertyName = rentSettings?.PropertyName ?? string.Empty;
+        var agentName = rentSettings?.AgentName ?? string.Empty;
         var monthName = new DateTime(payment.Year, payment.Month, 1).ToString("MMMM yyyy");
         var receiptRef = $"RCP-{payment.Year}{payment.Month:D2}-{payment.Room.Name.Replace(" ", "").ToUpperInvariant()[..Math.Min(4, payment.Room.Name.Length)]}";
 
@@ -27,7 +28,7 @@ public class RentReceiptPdfService
                 page.Margin(0);
                 page.DefaultTextStyle(x => x.FontSize(9).FontFamily("Arial").FontColor(Body));
 
-                var stampSvg = BuildReceiptStampSvg(companyName, receiptRef);
+                var stampSvg = BuildReceiptStampSvg(propertyName, receiptRef);
                 var stampImage = SvgImage.FromText(stampSvg);
 
                 page.Foreground()
@@ -44,12 +45,17 @@ public class RentReceiptPdfService
                     {
                         row.RelativeItem().Column(left =>
                         {
-                            left.Item().Text(companyName)
+                            left.Item().Text(propertyName)
                                 .FontSize(16).Bold().FontColor("#ffffff");
 
-                            if (!string.IsNullOrEmpty(company?.Phone))
+                            if (!string.IsNullOrEmpty(agentName))
                                 left.Item().PaddingTop(4)
-                                    .Text(company.Phone)
+                                    .Text($"Agent: {agentName}")
+                                    .FontSize(8).FontColor("#cccccc");
+
+                            if (!string.IsNullOrEmpty(rentSettings?.AgentPhone))
+                                left.Item().PaddingTop(2)
+                                    .Text(rentSettings.AgentPhone)
                                     .FontSize(8).FontColor("#cccccc");
                         });
 
@@ -97,19 +103,23 @@ public class RentReceiptPdfService
                                 .FontSize(7).Bold().FontColor(Gold).LetterSpacing(0.15f);
 
                             from.Item().PaddingTop(5)
-                                .Text(companyName)
+                                .Text(propertyName)
                                 .FontSize(10).Bold().FontColor(Navy);
 
-                            if (!string.IsNullOrEmpty(company?.AddressLine1))
-                                from.Item().Text(company.AddressLine1)
+                            if (!string.IsNullOrEmpty(agentName))
+                                from.Item().PaddingTop(2).Text($"Agent: {agentName}")
                                     .FontSize(8.5f).FontColor("#555555");
 
-                            if (!string.IsNullOrEmpty(company?.AddressLine2))
-                                from.Item().Text(company.AddressLine2)
+                            if (!string.IsNullOrEmpty(rentSettings?.AddressLine1))
+                                from.Item().Text(rentSettings.AddressLine1)
                                     .FontSize(8.5f).FontColor("#555555");
 
-                            if (!string.IsNullOrEmpty(company?.City))
-                                from.Item().Text($"{company.City} {company.PostalCode}")
+                            if (!string.IsNullOrEmpty(rentSettings?.AddressLine2))
+                                from.Item().Text(rentSettings.AddressLine2)
+                                    .FontSize(8.5f).FontColor("#555555");
+
+                            if (!string.IsNullOrEmpty(rentSettings?.City))
+                                from.Item().Text($"{rentSettings.City} {rentSettings.PostalCode}")
                                     .FontSize(8.5f).FontColor("#555555");
                         });
 
@@ -258,7 +268,7 @@ public class RentReceiptPdfService
                     .Text(txt =>
                     {
                         txt.Span("Thank you  —  ").FontColor("#aaaaaa").FontSize(8);
-                        txt.Span(companyName).FontColor("#cccccc").FontSize(8).Bold();
+                        txt.Span(propertyName).FontColor("#cccccc").FontSize(8).Bold();
                         txt.Span($"  —  {receiptRef}").FontColor("#aaaaaa").FontSize(8);
                     });
             });

--- a/InvoiceApp.Web/Pages/Rent/DownloadReceipt.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Rent/DownloadReceipt.cshtml.cs
@@ -26,10 +26,10 @@ public class DownloadReceiptModel : PageModel
         if (payment == null || !payment.IsPaid)
             return NotFound();
 
-        var company = await _db.CompanySettings.FirstOrDefaultAsync();
+        var rentSettings = await _db.RentSettings.FirstOrDefaultAsync();
         var banking = await _db.BankingDetails.FirstOrDefaultAsync();
 
-        var pdf = _pdfService.Generate(payment, company, banking);
+        var pdf = _pdfService.Generate(payment, rentSettings, banking);
 
         var roomSlug = payment.Room.Name.Replace(" ", "-").ToLowerInvariant();
         var filename = $"receipt-{roomSlug}-{payment.Year}-{payment.Month:D2}.pdf";

--- a/InvoiceApp.Web/Pages/Rent/Index.cshtml
+++ b/InvoiceApp.Web/Pages/Rent/Index.cshtml
@@ -129,10 +129,14 @@ else
                             Paid @(p.PaidDate.HasValue ? p.PaidDate.Value.ToString("dd MMM yyyy") : "")
                             @if (!string.IsNullOrEmpty(p.Notes)) { <span>— @p.Notes</span> }
                         </div>
-                        <div class="d-flex gap-2 mt-1">
+                        <div class="d-flex gap-2 mt-1 flex-wrap">
+                            <a href="/Rent/ReceiptPreview?paymentId=@p.Id"
+                               class="btn btn-warning btn-sm flex-fill" title="Print Receipt">
+                                <i class="bi bi-printer"></i> Print
+                            </a>
                             <a href="/Rent/DownloadReceipt?paymentId=@p.Id"
-                               class="btn btn-warning btn-sm flex-fill" title="Download Receipt">
-                                <i class="bi bi-download"></i> Receipt
+                               class="btn btn-outline-warning btn-sm flex-fill" title="Download PDF">
+                                <i class="bi bi-download"></i> PDF
                             </a>
                             <form method="post" asp-page-handler="Undo" asp-route-id="@p.Id"
                                   asp-route-month="@Model.Month" asp-route-year="@Model.Year" class="flex-fill">
@@ -226,9 +230,13 @@ else
                                     else
                                     {
                                         <div class="d-flex gap-1 justify-content-end">
+                                            <a href="/Rent/ReceiptPreview?paymentId=@p.Id"
+                                               class="btn btn-warning btn-sm" title="Print Receipt">
+                                                <i class="bi bi-printer"></i> Print
+                                            </a>
                                             <a href="/Rent/DownloadReceipt?paymentId=@p.Id"
-                                               class="btn btn-warning btn-sm" title="Download Receipt">
-                                                <i class="bi bi-download"></i> Receipt
+                                               class="btn btn-outline-warning btn-sm" title="Download PDF">
+                                                <i class="bi bi-download"></i> PDF
                                             </a>
                                             <form method="post" asp-page-handler="Undo" asp-route-id="@p.Id"
                                                   asp-route-month="@Model.Month" asp-route-year="@Model.Year">

--- a/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml
+++ b/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml
@@ -1,0 +1,376 @@
+@page
+@model InvoiceApp.Web.Pages.Rent.ReceiptPreviewModel
+@{
+    ViewData["Title"] = "Rent Receipt";
+    Layout = null;
+
+    var p = Model.Payment;
+    var rs = Model.RentSettings;
+    var banking = Model.Banking;
+    var monthName = new DateTime(p.Year, p.Month, 1).ToString("MMMM yyyy");
+    var receiptRef = $"RCP-{p.Year}{p.Month:D2}-{p.Room.Name.Replace(" ", "").ToUpperInvariant()[..Math.Min(4, p.Room.Name.Length)]}";
+    var paid = p.AmountPaid ?? p.AmountDue;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rent Receipt — @receiptRef</title>
+    <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <style>
+        :root {
+            --navy: #1a1a2e;
+            --gold: #e8c84a;
+        }
+
+        body {
+            background: #e9ecef;
+            font-family: Arial, sans-serif;
+        }
+
+        /* ── PRINT TOOLBAR ── */
+        .print-toolbar {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: var(--navy);
+            padding: 10px 20px;
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .print-toolbar .btn-gold {
+            background: var(--gold);
+            color: var(--navy);
+            font-weight: 700;
+            border: none;
+        }
+
+        /* ── RECEIPT CARD ── */
+        .receipt-wrap {
+            max-width: 800px;
+            margin: 24px auto 80px;
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.15);
+            overflow: hidden;
+            position: relative;
+        }
+
+        /* ── HEADER ── */
+        .receipt-header {
+            background: var(--navy);
+            color: #fff;
+            padding: 20px 28px;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
+
+        .receipt-header .property-name { font-size: 1.2rem; font-weight: 700; }
+        .receipt-header .meta-label { color: #aaa; font-size: 0.75rem; }
+        .receipt-header .meta-value { color: #fff; font-size: 0.8rem; font-weight: 600; }
+        .receipt-title { color: var(--gold); font-size: 1.5rem; font-weight: 900; letter-spacing: 2px; }
+
+        .gold-bar { height: 5px; background: var(--gold); }
+
+        /* ── FROM / TO ROW ── */
+        .address-row { display: flex; }
+        .from-box {
+            flex: 1;
+            border-left: 5px solid var(--gold);
+            padding: 16px 20px;
+        }
+        .to-box {
+            flex: 1;
+            background: var(--navy);
+            padding: 16px 20px;
+            color: #fff;
+        }
+        .section-label {
+            font-size: 0.65rem;
+            font-weight: 700;
+            letter-spacing: 2px;
+            color: var(--gold);
+            text-transform: uppercase;
+        }
+        .from-box .section-label { color: var(--gold); }
+
+        /* ── PAYMENT TABLE ── */
+        .items-section { padding: 20px 28px; }
+        .items-table { width: 100%; border-collapse: collapse; }
+        .items-table thead th {
+            background: var(--navy);
+            color: #fff;
+            font-size: 0.75rem;
+            padding: 8px 12px;
+        }
+        .items-table tbody td {
+            padding: 10px 12px;
+            border-bottom: 1px solid #eee;
+            font-size: 0.85rem;
+        }
+        .total-row td {
+            background: var(--navy);
+            color: #fff;
+            font-weight: 700;
+            font-size: 0.95rem;
+            padding: 10px 12px;
+            border: none;
+        }
+        .total-row td:last-child { color: var(--gold); }
+
+        /* ── NOTES ── */
+        .notes-section {
+            margin: 0 28px 16px;
+            border-left: 4px solid var(--gold);
+            background: #fffbea;
+            padding: 10px 14px;
+            font-size: 0.85rem;
+        }
+
+        /* ── BANKING ── */
+        .banking-section {
+            margin: 0 28px 24px;
+            background: #f8f9fa;
+            padding: 14px;
+            border-radius: 4px;
+        }
+        .banking-label { font-size: 0.65rem; color: #888; letter-spacing: 1.5px; text-transform: uppercase; }
+        .banking-value { font-size: 0.875rem; font-weight: 700; color: var(--navy); }
+
+        /* ── PAID STAMP ── */
+        .invoice-stamp {
+            position: absolute;
+            bottom: 80px;
+            right: 30px;
+            width: 120px;
+            height: 120px;
+            opacity: 0.2;
+            transform: rotate(-12deg);
+            pointer-events: none;
+        }
+
+        /* ── FOOTER BAR ── */
+        .receipt-footer {
+            background: var(--navy);
+            color: #aaa;
+            text-align: center;
+            padding: 8px;
+            font-size: 0.75rem;
+        }
+
+        .paid-confirm {
+            text-align: center;
+            font-size: 0.85rem;
+            font-weight: 700;
+            color: var(--gold);
+            letter-spacing: 2px;
+            padding: 12px 28px 0;
+        }
+
+        /* ── PRINT STYLES ── */
+        @@media print {
+            body { background: white; }
+            .print-toolbar { display: none !important; }
+            .receipt-wrap {
+                box-shadow: none;
+                margin: 0;
+                border-radius: 0;
+                max-width: 100%;
+                overflow: visible;
+            }
+            .invoice-stamp { opacity: 0.15; bottom: 100px; }
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Print toolbar -->
+    <div class="print-toolbar no-print">
+        <button onclick="window.print()" class="btn btn-gold">
+            <i class="bi bi-printer"></i> Print Receipt
+        </button>
+        <a href="/Rent/DownloadReceipt?paymentId=@p.Id" class="btn btn-warning">
+            <i class="bi bi-download"></i> Download PDF
+        </a>
+        <a href="/Rent" class="btn btn-outline-light btn-sm ms-auto">
+            <i class="bi bi-arrow-left"></i> Back
+        </a>
+    </div>
+
+    <div class="receipt-wrap">
+
+        <!-- STAMP -->
+        <svg class="invoice-stamp" viewBox="0 0 130 130" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <path id="topArc" d="M 9,65 A 56,56 0 0,1 121,65" fill="none"/>
+            </defs>
+            <circle cx="65" cy="65" r="61" fill="none" stroke="#1a1a2e" stroke-width="3"/>
+            <circle cx="65" cy="65" r="52" fill="none" stroke="#1a1a2e" stroke-width="1.5"/>
+            <text font-size="9" font-weight="700" fill="#1a1a2e" letter-spacing="1.5">
+                <textPath href="#topArc" startOffset="50%" text-anchor="middle">@((rs?.PropertyName ?? "").ToUpperInvariant())</textPath>
+            </text>
+            <line x1="24" y1="48" x2="106" y2="48" stroke="#1a1a2e" stroke-width="1"/>
+            <line x1="24" y1="86" x2="106" y2="86" stroke="#1a1a2e" stroke-width="1"/>
+            <text x="65" y="65" text-anchor="middle" font-size="11" font-weight="900" fill="#1a1a2e" letter-spacing="1">RENT</text>
+            <text x="65" y="80" text-anchor="middle" font-size="11" font-weight="700" fill="#1a1a2e" letter-spacing="1">RECEIPT</text>
+            <text x="65" y="103" text-anchor="middle" font-size="7" font-weight="600" fill="#1a1a2e" letter-spacing="1">@receiptRef</text>
+        </svg>
+
+        <!-- HEADER -->
+        <div class="receipt-header">
+            <div>
+                <div class="property-name">@(rs?.PropertyName ?? "Property")</div>
+                @if (!string.IsNullOrEmpty(rs?.AgentName))
+                {
+                    <div style="color:#ccc;font-size:0.8rem;margin-top:4px">Agent: @rs.AgentName</div>
+                }
+                @if (!string.IsNullOrEmpty(rs?.AgentPhone))
+                {
+                    <div style="color:#ccc;font-size:0.75rem">@rs.AgentPhone</div>
+                }
+            </div>
+            <div style="text-align:right">
+                <div class="receipt-title">RENT RECEIPT</div>
+                <div style="margin-top:4px">
+                    <span class="meta-label">Ref: </span><span class="meta-value">@receiptRef</span>
+                </div>
+                <div>
+                    <span class="meta-label">Period: </span><span class="meta-value">@monthName</span>
+                </div>
+                @if (p.PaidDate.HasValue)
+                {
+                    <div>
+                        <span class="meta-label">Paid: </span>
+                        <span class="meta-value">@p.PaidDate.Value.ToString("dd MMM yyyy")</span>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div class="gold-bar"></div>
+
+        <!-- FROM / TO -->
+        <div class="address-row">
+            <div class="from-box">
+                <div class="section-label">From</div>
+                <div style="font-size:1rem;font-weight:700;color:var(--navy);margin-top:6px">
+                    @(rs?.PropertyName ?? "Property")
+                </div>
+                @if (!string.IsNullOrEmpty(rs?.AgentName))
+                {
+                    <div style="font-size:0.85rem;color:#555;margin-top:2px">Agent: @rs.AgentName</div>
+                }
+                @if (!string.IsNullOrEmpty(rs?.AddressLine1))
+                {
+                    <div style="font-size:0.82rem;color:#555">@rs.AddressLine1</div>
+                }
+                @if (!string.IsNullOrEmpty(rs?.AddressLine2))
+                {
+                    <div style="font-size:0.82rem;color:#555">@rs.AddressLine2</div>
+                }
+                @if (!string.IsNullOrEmpty(rs?.City))
+                {
+                    <div style="font-size:0.82rem;color:#555">@rs.City @rs.PostalCode</div>
+                }
+            </div>
+            <div class="to-box">
+                <div class="section-label">Tenant</div>
+                <div style="font-size:1rem;font-weight:700;margin-top:6px">@p.Room.TenantName</div>
+                <div style="font-size:0.8rem;color:#aaa;margin-top:4px">Room: @p.Room.Name</div>
+                @if (!string.IsNullOrEmpty(p.Room.TenantPhone))
+                {
+                    <div style="font-size:0.8rem;color:#aaa">Phone: @p.Room.TenantPhone</div>
+                }
+            </div>
+        </div>
+
+        <div style="height:2px;background:#e0e0e0"></div>
+
+        <!-- PAYMENT TABLE -->
+        <div class="items-section">
+            <table class="items-table">
+                <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th class="text-end">Amount (R)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr style="background:#f8f9fa">
+                        <td><strong>Rent — @p.Room.Name (@monthName)</strong></td>
+                        <td class="text-end">@p.AmountDue.ToString("N2")</td>
+                    </tr>
+                    @if (p.AmountPaid.HasValue && p.AmountPaid != p.AmountDue)
+                    {
+                        <tr>
+                            <td style="color:#888">Amount Due</td>
+                            <td class="text-end" style="color:#888">@p.AmountDue.ToString("N2")</td>
+                        </tr>
+                    }
+                    <tr class="total-row">
+                        <td>AMOUNT RECEIVED</td>
+                        <td class="text-end">R @paid.ToString("N2")</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        @if (!string.IsNullOrEmpty(p.Notes))
+        {
+            <div class="notes-section">
+                <strong>Notes:</strong> @p.Notes
+            </div>
+        }
+
+        @if (banking != null && !string.IsNullOrEmpty(banking.BankName))
+        {
+            <div class="banking-section">
+                <div class="banking-label mb-2">Banking Details</div>
+                <div class="row g-3">
+                    <div class="col-6 col-md-3">
+                        <div class="banking-label">Bank</div>
+                        <div class="banking-value">@banking.BankName</div>
+                    </div>
+                    @if (!string.IsNullOrEmpty(banking.AccountNumber))
+                    {
+                        <div class="col-6 col-md-3">
+                            <div class="banking-label">Account Number</div>
+                            <div class="banking-value">@banking.AccountNumber</div>
+                        </div>
+                    }
+                    @if (!string.IsNullOrEmpty(banking.AccountType))
+                    {
+                        <div class="col-6 col-md-3">
+                            <div class="banking-label">Account Type</div>
+                            <div class="banking-value">@banking.AccountType</div>
+                        </div>
+                    }
+                    @if (!string.IsNullOrEmpty(banking.BranchCode))
+                    {
+                        <div class="col-6 col-md-3">
+                            <div class="banking-label">Branch Code</div>
+                            <div class="banking-value">@banking.BranchCode</div>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+
+        <div class="paid-confirm">PAYMENT RECEIVED IN FULL</div>
+        <div style="height:16px"></div>
+
+        <!-- FOOTER -->
+        <div class="receipt-footer">
+            Thank you &mdash; <strong>@(rs?.PropertyName ?? "")</strong> &mdash; @receiptRef
+        </div>
+
+    </div>
+
+    <script src="/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml.cs
@@ -1,0 +1,34 @@
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace InvoiceApp.Web.Pages.Rent;
+
+public class ReceiptPreviewModel : PageModel
+{
+    private readonly AppDbContext _db;
+
+    public ReceiptPreviewModel(AppDbContext db) => _db = db;
+
+    public RentPayment Payment { get; set; } = null!;
+    public RentSettings? RentSettings { get; set; }
+    public BankingDetails? Banking { get; set; }
+
+    public async Task<IActionResult> OnGetAsync(int paymentId)
+    {
+        var payment = await _db.RentPayments
+            .Include(p => p.Room)
+            .FirstOrDefaultAsync(p => p.Id == paymentId);
+
+        if (payment == null || !payment.IsPaid)
+            return NotFound();
+
+        Payment = payment;
+        RentSettings = await _db.RentSettings.FirstOrDefaultAsync();
+        Banking = await _db.BankingDetails.FirstOrDefaultAsync();
+
+        return Page();
+    }
+}

--- a/InvoiceApp.Web/Pages/Settings/Rooms.cshtml
+++ b/InvoiceApp.Web/Pages/Settings/Rooms.cshtml
@@ -32,6 +32,53 @@
     </div>
 }
 
+@* ── PROPERTY / AGENT SETTINGS ── *@
+<div class="card mb-4">
+    <div class="card-header fw-semibold"><i class="bi bi-building"></i> Property / Agent Details</div>
+    <div class="card-body">
+        <p class="text-muted small mb-3">This appears as the <strong>FROM</strong> section on rent receipts.</p>
+        <form method="post" asp-page-handler="SaveProperty">
+            <div class="row g-3">
+                <div class="col-12 col-md-6">
+                    <label class="form-label">Property / Cottage Name <span class="text-danger">*</span></label>
+                    <input asp-for="Property.PropertyName" class="form-control" placeholder="e.g. Sunset Cottages" />
+                    <span asp-validation-for="Property.PropertyName" class="text-danger small"></span>
+                </div>
+                <div class="col-12 col-md-6">
+                    <label class="form-label">Agent Name <span class="text-danger">*</span></label>
+                    <input asp-for="Property.AgentName" class="form-control" placeholder="e.g. John Smith" />
+                    <span asp-validation-for="Property.AgentName" class="text-danger small"></span>
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label">Agent Phone</label>
+                    <input asp-for="Property.AgentPhone" class="form-control" placeholder="082 000 0000" />
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label">Address Line 1</label>
+                    <input asp-for="Property.AddressLine1" class="form-control" placeholder="Street address" />
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label">Address Line 2</label>
+                    <input asp-for="Property.AddressLine2" class="form-control" placeholder="Suburb" />
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label">City</label>
+                    <input asp-for="Property.City" class="form-control" placeholder="City" />
+                </div>
+                <div class="col-12 col-md-4">
+                    <label class="form-label">Postal Code</label>
+                    <input asp-for="Property.PostalCode" class="form-control" placeholder="0000" />
+                </div>
+                <div class="col-12 col-md-4 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary w-100">
+                        <i class="bi bi-save"></i> Save Property Details
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
 @if (!Model.Rooms.Any())
 {
     <p class="text-muted text-center py-4">No rooms yet. Add one below.</p>

--- a/InvoiceApp.Web/Pages/Settings/Rooms.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Settings/Rooms.cshtml.cs
@@ -14,6 +14,8 @@ public class RoomsModel : PageModel
 
     public List<Room> Rooms { get; set; } = new();
 
+    [BindProperty] public RentSettings Property { get; set; } = new();
+
     [BindProperty] public string NewName { get; set; } = string.Empty;
     [BindProperty] public string NewTenantName { get; set; } = string.Empty;
     [BindProperty] public string NewTenantPhone { get; set; } = string.Empty;
@@ -25,11 +27,59 @@ public class RoomsModel : PageModel
     [BindProperty] public string EditTenantPhone { get; set; } = string.Empty;
     [BindProperty] public decimal EditRentAmount { get; set; }
 
-    public string? StatusMessage { get; set; }
+    [TempData] public string? StatusMessage { get; set; }
 
     public async Task OnGetAsync()
     {
         Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
+        Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
+    }
+
+    public async Task<IActionResult> OnPostSavePropertyAsync()
+    {
+        Property.PropertyName = Property.PropertyName?.Trim() ?? string.Empty;
+        Property.AgentName = Property.AgentName?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(Property.PropertyName))
+            ModelState.AddModelError("Property.PropertyName", "Property name is required.");
+
+        if (string.IsNullOrWhiteSpace(Property.AgentName))
+            ModelState.AddModelError("Property.AgentName", "Agent name is required.");
+
+        if (!ModelState.IsValid)
+        {
+            Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
+            return Page();
+        }
+
+        var existing = await _db.RentSettings.FirstOrDefaultAsync();
+        if (existing == null)
+        {
+            _db.RentSettings.Add(new RentSettings
+            {
+                PropertyName = Property.PropertyName,
+                AgentName = Property.AgentName,
+                AgentPhone = Property.AgentPhone?.Trim(),
+                AddressLine1 = Property.AddressLine1?.Trim(),
+                AddressLine2 = Property.AddressLine2?.Trim(),
+                City = Property.City?.Trim(),
+                PostalCode = Property.PostalCode?.Trim()
+            });
+        }
+        else
+        {
+            existing.PropertyName = Property.PropertyName;
+            existing.AgentName = Property.AgentName;
+            existing.AgentPhone = Property.AgentPhone?.Trim();
+            existing.AddressLine1 = Property.AddressLine1?.Trim();
+            existing.AddressLine2 = Property.AddressLine2?.Trim();
+            existing.City = Property.City?.Trim();
+            existing.PostalCode = Property.PostalCode?.Trim();
+        }
+
+        await _db.SaveChangesAsync();
+        TempData["StatusMessage"] = "Property settings saved.";
+        return RedirectToPage();
     }
 
     public async Task<IActionResult> OnPostAddAsync()
@@ -39,18 +89,15 @@ public class RoomsModel : PageModel
         NewTenantPhone = NewTenantPhone?.Trim() ?? string.Empty;
 
         if (string.IsNullOrWhiteSpace(NewName))
-        {
             ModelState.AddModelError("NewName", "Room name is required.");
-        }
 
         if (NewRentAmount < 0)
-        {
             ModelState.AddModelError("NewRentAmount", "Rent amount cannot be negative.");
-        }
 
         if (!ModelState.IsValid)
         {
             Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
+            Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
             return Page();
         }
 
@@ -63,9 +110,8 @@ public class RoomsModel : PageModel
             IsActive = true
         });
         await _db.SaveChangesAsync();
-        StatusMessage = "Room added.";
-        Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-        return Page();
+        TempData["StatusMessage"] = "Room added.";
+        return RedirectToPage();
     }
 
     public async Task<IActionResult> OnPostEditAsync()
@@ -86,6 +132,7 @@ public class RoomsModel : PageModel
         if (!ModelState.IsValid)
         {
             Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
+            Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
             return Page();
         }
 
@@ -94,9 +141,8 @@ public class RoomsModel : PageModel
         room.TenantPhone = EditTenantPhone;
         room.RentAmount = EditRentAmount;
         await _db.SaveChangesAsync();
-        StatusMessage = "Room updated.";
-        Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-        return Page();
+        TempData["StatusMessage"] = "Room updated.";
+        return RedirectToPage();
     }
 
     public async Task<IActionResult> OnPostToggleAsync(int id)
@@ -106,8 +152,7 @@ public class RoomsModel : PageModel
 
         room.IsActive = !room.IsActive;
         await _db.SaveChangesAsync();
-        StatusMessage = room.IsActive ? $"'{room.Name}' activated." : $"'{room.Name}' deactivated.";
-        Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-        return Page();
+        TempData["StatusMessage"] = room.IsActive ? $"'{room.Name}' activated." : $"'{room.Name}' deactivated.";
+        return RedirectToPage();
     }
 }


### PR DESCRIPTION
## Summary

- Add `RentSettings` entity (PropertyName, AgentName, AgentPhone, Address) with EF migration
- The **FROM** section on rent receipts now shows the property/cottage name and agent — not the invoice company
- Add Property/Agent Details section to **Settings > Rooms** page for one-time setup
- Add `/Rent/ReceiptPreview` — HTML preview page with sticky Print + Download PDF toolbar (same pattern as invoice preview)
- Split Rent/Index buttons for paid rooms into: **Print** (opens preview) | **PDF** (direct download) | **Undo**

## Test plan

- [ ] Go to Settings > Rooms and fill in Property/Cottage name + Agent name — save
- [ ] Mark a room as paid, click Print — ReceiptPreview opens showing the property/agent in the FROM section
- [ ] Click Print Receipt button — browser print dialog opens, toolbar hides
- [ ] Click Download PDF — PDF downloads with correct FROM section
- [ ] Verify receipt FROM does NOT show invoice company details

Closes #14

Generated with [Claude Code](https://claude.ai/claude-code)