### PR TITLE
refactor: replace RentSettings with Property entity (proper room-property relationship)

### DIFF
--- a/InvoiceApp.Core/Entities/Property.cs
+++ b/InvoiceApp.Core/Entities/Property.cs
@@ -1,0 +1,14 @@
+namespace InvoiceApp.Core.Entities;
+
+public class Property
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string AgentName { get; set; } = string.Empty;
+    public string? AgentPhone { get; set; }
+    public string? AddressLine1 { get; set; }
+    public string? AddressLine2 { get; set; }
+    public string? City { get; set; }
+    public string? PostalCode { get; set; }
+    public ICollection<Room> Rooms { get; set; } = new List<Room>();
+}

--- a/InvoiceApp.Core/Entities/Room.cs
+++ b/InvoiceApp.Core/Entities/Room.cs
@@ -8,5 +8,7 @@ public class Room
     public string TenantPhone { get; set; } = string.Empty;
     public decimal RentAmount { get; set; }
     public bool IsActive { get; set; } = true;
+    public int? PropertyId { get; set; }
+    public Property? Property { get; set; }
     public ICollection<RentPayment> Payments { get; set; } = new List<RentPayment>();
 }

--- a/InvoiceApp.Infrastructure/Data/AppDbContext.cs
+++ b/InvoiceApp.Infrastructure/Data/AppDbContext.cs
@@ -14,7 +14,7 @@ public class AppDbContext : DbContext
     public DbSet<SavedRate> SavedRates => Set<SavedRate>();
     public DbSet<Room> Rooms => Set<Room>();
     public DbSet<RentPayment> RentPayments => Set<RentPayment>();
-    public DbSet<RentSettings> RentSettings => Set<RentSettings>();
+    public DbSet<Property> Properties => Set<Property>();
     public DbSet<ErrorLog> ErrorLogs => Set<ErrorLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -23,6 +23,12 @@ public class AppDbContext : DbContext
 
         modelBuilder.Entity<Room>()
             .Property(r => r.RentAmount).HasColumnType("decimal(18,2)");
+
+        modelBuilder.Entity<Room>()
+            .HasOne(r => r.Property)
+            .WithMany(p => p.Rooms)
+            .HasForeignKey(r => r.PropertyId)
+            .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder.Entity<RentPayment>(b =>
         {

--- a/InvoiceApp.Infrastructure/Migrations/20260419130203_AddPropertyAndLinkRooms.Designer.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419130203_AddPropertyAndLinkRooms.Designer.cs
@@ -4,6 +4,7 @@ using InvoiceApp.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace InvoiceApp.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419130203_AddPropertyAndLinkRooms")]
+    partial class AddPropertyAndLinkRooms
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/InvoiceApp.Infrastructure/Migrations/20260419130203_AddPropertyAndLinkRooms.cs
+++ b/InvoiceApp.Infrastructure/Migrations/20260419130203_AddPropertyAndLinkRooms.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InvoiceApp.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPropertyAndLinkRooms : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RentSettings",
+                schema: "blacktech");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PropertyId",
+                schema: "blacktech",
+                table: "Rooms",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Properties",
+                schema: "blacktech",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AgentName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AgentPhone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AddressLine1 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AddressLine2 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Properties", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Rooms_PropertyId",
+                schema: "blacktech",
+                table: "Rooms",
+                column: "PropertyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Rooms_Properties_PropertyId",
+                schema: "blacktech",
+                table: "Rooms",
+                column: "PropertyId",
+                principalSchema: "blacktech",
+                principalTable: "Properties",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Rooms_Properties_PropertyId",
+                schema: "blacktech",
+                table: "Rooms");
+
+            migrationBuilder.DropTable(
+                name: "Properties",
+                schema: "blacktech");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Rooms_PropertyId",
+                schema: "blacktech",
+                table: "Rooms");
+
+            migrationBuilder.DropColumn(
+                name: "PropertyId",
+                schema: "blacktech",
+                table: "Rooms");
+
+            migrationBuilder.CreateTable(
+                name: "RentSettings",
+                schema: "blacktech",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    AddressLine1 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AddressLine2 = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AgentName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AgentPhone = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    City = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PropertyName = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RentSettings", x => x.Id);
+                });
+        }
+    }
+}

--- a/InvoiceApp.Infrastructure/Services/RentReceiptPdfService.cs
+++ b/InvoiceApp.Infrastructure/Services/RentReceiptPdfService.cs
@@ -13,10 +13,10 @@ public class RentReceiptPdfService
     private const string Muted = "#888888";
     private const string Body  = "#333333";
 
-    public byte[] Generate(RentPayment payment, RentSettings? rentSettings, BankingDetails? banking)
+    public byte[] Generate(RentPayment payment, BankingDetails? banking)
     {
-        var propertyName = rentSettings?.PropertyName ?? string.Empty;
-        var agentName = rentSettings?.AgentName ?? string.Empty;
+        var propertyName = payment.Room.Property?.Name ?? string.Empty;
+        var agentName = payment.Room.Property?.AgentName ?? string.Empty;
         var monthName = new DateTime(payment.Year, payment.Month, 1).ToString("MMMM yyyy");
         var receiptRef = $"RCP-{payment.Year}{payment.Month:D2}-{payment.Room.Name.Replace(" ", "").ToUpperInvariant()[..Math.Min(4, payment.Room.Name.Length)]}";
 
@@ -53,9 +53,9 @@ public class RentReceiptPdfService
                                     .Text($"Agent: {agentName}")
                                     .FontSize(8).FontColor("#cccccc");
 
-                            if (!string.IsNullOrEmpty(rentSettings?.AgentPhone))
+                            if (!string.IsNullOrEmpty(payment.Room.Property?.AgentPhone))
                                 left.Item().PaddingTop(2)
-                                    .Text(rentSettings.AgentPhone)
+                                    .Text(payment.Room.Property.AgentPhone)
                                     .FontSize(8).FontColor("#cccccc");
                         });
 
@@ -110,16 +110,16 @@ public class RentReceiptPdfService
                                 from.Item().PaddingTop(2).Text($"Agent: {agentName}")
                                     .FontSize(8.5f).FontColor("#555555");
 
-                            if (!string.IsNullOrEmpty(rentSettings?.AddressLine1))
-                                from.Item().Text(rentSettings.AddressLine1)
+                            if (!string.IsNullOrEmpty(payment.Room.Property?.AddressLine1))
+                                from.Item().Text(payment.Room.Property.AddressLine1)
                                     .FontSize(8.5f).FontColor("#555555");
 
-                            if (!string.IsNullOrEmpty(rentSettings?.AddressLine2))
-                                from.Item().Text(rentSettings.AddressLine2)
+                            if (!string.IsNullOrEmpty(payment.Room.Property?.AddressLine2))
+                                from.Item().Text(payment.Room.Property.AddressLine2)
                                     .FontSize(8.5f).FontColor("#555555");
 
-                            if (!string.IsNullOrEmpty(rentSettings?.City))
-                                from.Item().Text($"{rentSettings.City} {rentSettings.PostalCode}")
+                            if (!string.IsNullOrEmpty(payment.Room.Property?.City))
+                                from.Item().Text($"{payment.Room.Property.City} {payment.Room.Property.PostalCode}")
                                     .FontSize(8.5f).FontColor("#555555");
                         });
 

--- a/InvoiceApp.Tests/Data/PropertyTests.cs
+++ b/InvoiceApp.Tests/Data/PropertyTests.cs
@@ -1,0 +1,158 @@
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Infrastructure.Data;
+using InvoiceApp.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using QuestPDF.Infrastructure;
+using Xunit;
+
+namespace InvoiceApp.Tests.Data;
+
+public class PropertyTests
+{
+    private static AppDbContext CreateInMemoryDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task Property_Can_Be_Created_And_Retrieved()
+    {
+        using var db = CreateInMemoryDb();
+
+        db.Properties.Add(new Property
+        {
+            Name = "Sunset Cottages",
+            AgentName = "John Smith",
+            AgentPhone = "082 000 0000",
+            AddressLine1 = "10 Main Street",
+            City = "Durban"
+        });
+        await db.SaveChangesAsync();
+
+        var saved = await db.Properties.FirstOrDefaultAsync();
+
+        Assert.NotNull(saved);
+        Assert.Equal("Sunset Cottages", saved.Name);
+        Assert.Equal("John Smith", saved.AgentName);
+        Assert.Equal("Durban", saved.City);
+    }
+
+    [Fact]
+    public async Task Room_Can_Be_Linked_To_Property()
+    {
+        using var db = CreateInMemoryDb();
+
+        var property = new Property { Name = "Riverside Flats", AgentName = "Jane Doe" };
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        db.Rooms.Add(new Room
+        {
+            Name = "Unit 1",
+            TenantName = "Bob",
+            RentAmount = 4500m,
+            PropertyId = property.Id
+        });
+        await db.SaveChangesAsync();
+
+        var room = await db.Rooms.Include(r => r.Property).FirstAsync();
+
+        Assert.NotNull(room.Property);
+        Assert.Equal("Riverside Flats", room.Property.Name);
+        Assert.Equal(property.Id, room.PropertyId);
+    }
+
+    [Fact]
+    public async Task Room_PropertyId_Is_Nullable_When_Not_Linked()
+    {
+        using var db = CreateInMemoryDb();
+
+        db.Rooms.Add(new Room { Name = "Standalone Room", TenantName = "Alice", RentAmount = 3000m });
+        await db.SaveChangesAsync();
+
+        var room = await db.Rooms.Include(r => r.Property).FirstAsync();
+
+        Assert.Null(room.PropertyId);
+        Assert.Null(room.Property);
+    }
+
+    [Fact]
+    public async Task Multiple_Rooms_Can_Belong_To_Same_Property()
+    {
+        using var db = CreateInMemoryDb();
+
+        var property = new Property { Name = "Garden Cottages", AgentName = "Sam" };
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        db.Rooms.AddRange(
+            new Room { Name = "Cottage A", TenantName = "T1", RentAmount = 5000m, PropertyId = property.Id },
+            new Room { Name = "Cottage B", TenantName = "T2", RentAmount = 5500m, PropertyId = property.Id }
+        );
+        await db.SaveChangesAsync();
+
+        var rooms = await db.Rooms.Where(r => r.PropertyId == property.Id).ToListAsync();
+
+        Assert.Equal(2, rooms.Count);
+    }
+
+    [Fact]
+    public async Task Receipt_Pdf_Uses_Property_Name_When_Linked()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+        using var db = CreateInMemoryDb();
+
+        var property = new Property { Name = "Sunset Cottages", AgentName = "John Smith", AgentPhone = "082 000 0000" };
+        db.Properties.Add(property);
+
+        var room = new Room { Name = "Unit 1", TenantName = "Bob Tenant", RentAmount = 5000m, Property = property };
+        db.Rooms.Add(room);
+        await db.SaveChangesAsync();
+
+        var payment = new RentPayment
+        {
+            Room = room,
+            Month = 4,
+            Year = 2026,
+            AmountDue = 5000m,
+            AmountPaid = 5000m,
+            IsPaid = true,
+            PaidDate = new DateTime(2026, 4, 1)
+        };
+
+        var service = new RentReceiptPdfService();
+        var ex = Record.Exception(() => service.Generate(payment, null));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task Receipt_Pdf_Generates_Without_Property()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+        using var db = CreateInMemoryDb();
+
+        var room = new Room { Name = "Unit 2", TenantName = "No Property Tenant", RentAmount = 3000m };
+        db.Rooms.Add(room);
+        await db.SaveChangesAsync();
+
+        var payment = new RentPayment
+        {
+            Room = room,
+            Month = 4,
+            Year = 2026,
+            AmountDue = 3000m,
+            AmountPaid = 3000m,
+            IsPaid = true,
+            PaidDate = new DateTime(2026, 4, 1)
+        };
+
+        var service = new RentReceiptPdfService();
+        var ex = Record.Exception(() => service.Generate(payment, null));
+
+        Assert.Null(ex);
+    }
+}

--- a/InvoiceApp.Web/Pages/Rent/DownloadReceipt.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Rent/DownloadReceipt.cshtml.cs
@@ -20,16 +20,14 @@ public class DownloadReceiptModel : PageModel
     public async Task<IActionResult> OnGetAsync(int paymentId)
     {
         var payment = await _db.RentPayments
-            .Include(p => p.Room)
+            .Include(p => p.Room).ThenInclude(r => r.Property)
             .FirstOrDefaultAsync(p => p.Id == paymentId);
 
         if (payment == null || !payment.IsPaid)
             return NotFound();
 
-        var rentSettings = await _db.RentSettings.FirstOrDefaultAsync();
         var banking = await _db.BankingDetails.FirstOrDefaultAsync();
-
-        var pdf = _pdfService.Generate(payment, rentSettings, banking);
+        var pdf = _pdfService.Generate(payment, banking);
 
         var roomSlug = payment.Room.Name.Replace(" ", "-").ToLowerInvariant();
         var filename = $"receipt-{roomSlug}-{payment.Year}-{payment.Month:D2}.pdf";

--- a/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml
+++ b/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml
@@ -5,7 +5,7 @@
     Layout = null;
 
     var p = Model.Payment;
-    var rs = Model.RentSettings;
+    var prop = p.Room.Property;
     var banking = Model.Banking;
     var monthName = new DateTime(p.Year, p.Month, 1).ToString("MMMM yyyy");
     var receiptRef = $"RCP-{p.Year}{p.Month:D2}-{p.Room.Name.Replace(" ", "").ToUpperInvariant()[..Math.Min(4, p.Room.Name.Length)]}";
@@ -212,7 +212,7 @@
             <circle cx="65" cy="65" r="61" fill="none" stroke="#1a1a2e" stroke-width="3"/>
             <circle cx="65" cy="65" r="52" fill="none" stroke="#1a1a2e" stroke-width="1.5"/>
             <text font-size="9" font-weight="700" fill="#1a1a2e" letter-spacing="1.5">
-                <textPath href="#topArc" startOffset="50%" text-anchor="middle">@((rs?.PropertyName ?? "").ToUpperInvariant())</textPath>
+                <textPath href="#topArc" startOffset="50%" text-anchor="middle">@((prop?.Name ?? "").ToUpperInvariant())</textPath>
             </text>
             <line x1="24" y1="48" x2="106" y2="48" stroke="#1a1a2e" stroke-width="1"/>
             <line x1="24" y1="86" x2="106" y2="86" stroke="#1a1a2e" stroke-width="1"/>
@@ -224,14 +224,14 @@
         <!-- HEADER -->
         <div class="receipt-header">
             <div>
-                <div class="property-name">@(rs?.PropertyName ?? "Property")</div>
-                @if (!string.IsNullOrEmpty(rs?.AgentName))
+                <div class="property-name">@(prop?.Name ?? "Property")</div>
+                @if (!string.IsNullOrEmpty(prop?.AgentName))
                 {
-                    <div style="color:#ccc;font-size:0.8rem;margin-top:4px">Agent: @rs.AgentName</div>
+                    <div style="color:#ccc;font-size:0.8rem;margin-top:4px">Agent: @prop.AgentName</div>
                 }
-                @if (!string.IsNullOrEmpty(rs?.AgentPhone))
+                @if (!string.IsNullOrEmpty(prop?.AgentPhone))
                 {
-                    <div style="color:#ccc;font-size:0.75rem">@rs.AgentPhone</div>
+                    <div style="color:#ccc;font-size:0.75rem">@prop.AgentPhone</div>
                 }
             </div>
             <div style="text-align:right">
@@ -259,23 +259,23 @@
             <div class="from-box">
                 <div class="section-label">From</div>
                 <div style="font-size:1rem;font-weight:700;color:var(--navy);margin-top:6px">
-                    @(rs?.PropertyName ?? "Property")
+                    @(prop?.Name ?? "Property")
                 </div>
-                @if (!string.IsNullOrEmpty(rs?.AgentName))
+                @if (!string.IsNullOrEmpty(prop?.AgentName))
                 {
-                    <div style="font-size:0.85rem;color:#555;margin-top:2px">Agent: @rs.AgentName</div>
+                    <div style="font-size:0.85rem;color:#555;margin-top:2px">Agent: @prop.AgentName</div>
                 }
-                @if (!string.IsNullOrEmpty(rs?.AddressLine1))
+                @if (!string.IsNullOrEmpty(prop?.AddressLine1))
                 {
-                    <div style="font-size:0.82rem;color:#555">@rs.AddressLine1</div>
+                    <div style="font-size:0.82rem;color:#555">@prop.AddressLine1</div>
                 }
-                @if (!string.IsNullOrEmpty(rs?.AddressLine2))
+                @if (!string.IsNullOrEmpty(prop?.AddressLine2))
                 {
-                    <div style="font-size:0.82rem;color:#555">@rs.AddressLine2</div>
+                    <div style="font-size:0.82rem;color:#555">@prop.AddressLine2</div>
                 }
-                @if (!string.IsNullOrEmpty(rs?.City))
+                @if (!string.IsNullOrEmpty(prop?.City))
                 {
-                    <div style="font-size:0.82rem;color:#555">@rs.City @rs.PostalCode</div>
+                    <div style="font-size:0.82rem;color:#555">@prop.City @prop.PostalCode</div>
                 }
             </div>
             <div class="to-box">
@@ -366,7 +366,7 @@
 
         <!-- FOOTER -->
         <div class="receipt-footer">
-            Thank you &mdash; <strong>@(rs?.PropertyName ?? "")</strong> &mdash; @receiptRef
+            Thank you &mdash; <strong>@(prop?.Name ?? "")</strong> &mdash; @receiptRef
         </div>
 
     </div>

--- a/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Rent/ReceiptPreview.cshtml.cs
@@ -13,20 +13,18 @@ public class ReceiptPreviewModel : PageModel
     public ReceiptPreviewModel(AppDbContext db) => _db = db;
 
     public RentPayment Payment { get; set; } = null!;
-    public RentSettings? RentSettings { get; set; }
     public BankingDetails? Banking { get; set; }
 
     public async Task<IActionResult> OnGetAsync(int paymentId)
     {
         var payment = await _db.RentPayments
-            .Include(p => p.Room)
+            .Include(p => p.Room).ThenInclude(r => r.Property)
             .FirstOrDefaultAsync(p => p.Id == paymentId);
 
         if (payment == null || !payment.IsPaid)
             return NotFound();
 
         Payment = payment;
-        RentSettings = await _db.RentSettings.FirstOrDefaultAsync();
         Banking = await _db.BankingDetails.FirstOrDefaultAsync();
 
         return Page();

--- a/InvoiceApp.Web/Pages/Settings/Rooms.cshtml
+++ b/InvoiceApp.Web/Pages/Settings/Rooms.cshtml
@@ -24,68 +24,143 @@
     </div>
 }
 
-@if (!string.IsNullOrEmpty(Model.StatusMessage))
+@if (TempData["StatusMessage"] is string msg)
 {
     <div class="alert alert-success alert-dismissible fade show py-2" role="alert">
-        @Model.StatusMessage
+        @msg
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     </div>
 }
 
-@* ── PROPERTY / AGENT SETTINGS ── *@
+@* ── PROPERTIES ── *@
 <div class="card mb-4">
-    <div class="card-header fw-semibold"><i class="bi bi-building"></i> Property / Agent Details</div>
-    <div class="card-body">
-        <p class="text-muted small mb-3">This appears as the <strong>FROM</strong> section on rent receipts.</p>
-        <form method="post" asp-page-handler="SaveProperty">
-            <div class="row g-3">
-                <div class="col-12 col-md-6">
-                    <label class="form-label">Property / Cottage Name <span class="text-danger">*</span></label>
-                    <input asp-for="Property.PropertyName" class="form-control" placeholder="e.g. Sunset Cottages" />
-                    <span asp-validation-for="Property.PropertyName" class="text-danger small"></span>
-                </div>
-                <div class="col-12 col-md-6">
-                    <label class="form-label">Agent Name <span class="text-danger">*</span></label>
-                    <input asp-for="Property.AgentName" class="form-control" placeholder="e.g. John Smith" />
-                    <span asp-validation-for="Property.AgentName" class="text-danger small"></span>
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label">Agent Phone</label>
-                    <input asp-for="Property.AgentPhone" class="form-control" placeholder="082 000 0000" />
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label">Address Line 1</label>
-                    <input asp-for="Property.AddressLine1" class="form-control" placeholder="Street address" />
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label">Address Line 2</label>
-                    <input asp-for="Property.AddressLine2" class="form-control" placeholder="Suburb" />
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label">City</label>
-                    <input asp-for="Property.City" class="form-control" placeholder="City" />
-                </div>
-                <div class="col-12 col-md-4">
-                    <label class="form-label">Postal Code</label>
-                    <input asp-for="Property.PostalCode" class="form-control" placeholder="0000" />
-                </div>
-                <div class="col-12 col-md-4 d-flex align-items-end">
-                    <button type="submit" class="btn btn-primary w-100">
-                        <i class="bi bi-save"></i> Save Property Details
-                    </button>
-                </div>
+    <div class="card-header fw-semibold d-flex justify-content-between align-items-center">
+        <span><i class="bi bi-building"></i> Properties</span>
+        <button class="btn btn-primary btn-sm" data-bs-toggle="collapse" data-bs-target="#addPropertyForm">
+            <i class="bi bi-plus-lg"></i> Add Property
+        </button>
+    </div>
+    <div class="card-body p-0">
+
+        @* Add Property form (collapsed by default) *@
+        <div class="collapse" id="addPropertyForm">
+            <div class="p-3 border-bottom bg-light">
+                <p class="text-muted small mb-3">A property groups rooms together and appears as the <strong>FROM</strong> section on rent receipts.</p>
+                <form method="post" asp-page-handler="AddProperty">
+                    <div class="row g-2">
+                        <div class="col-12 col-md-4">
+                            <input asp-for="NewPropertyName" class="form-control form-control-sm" placeholder="Property / Cottage name *" />
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <input asp-for="NewPropertyAgent" class="form-control form-control-sm" placeholder="Agent name *" />
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <input asp-for="NewPropertyPhone" class="form-control form-control-sm" placeholder="Agent phone" />
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <input asp-for="NewPropertyAddress1" class="form-control form-control-sm" placeholder="Address line 1" />
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <input asp-for="NewPropertyAddress2" class="form-control form-control-sm" placeholder="Address line 2" />
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <input asp-for="NewPropertyCity" class="form-control form-control-sm" placeholder="City" />
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <input asp-for="NewPropertyPostalCode" class="form-control form-control-sm" placeholder="Postal code" />
+                        </div>
+                        <div class="col-12 d-flex gap-2">
+                            <button type="submit" class="btn btn-primary btn-sm">
+                                <i class="bi bi-save"></i> Save Property
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary btn-sm"
+                                    data-bs-toggle="collapse" data-bs-target="#addPropertyForm">Cancel</button>
+                        </div>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
+
+        @if (!Model.Properties.Any())
+        {
+            <p class="text-muted text-center py-3 mb-0">No properties yet. Add one above before adding rooms.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover mb-0 align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Property</th>
+                            <th>Agent</th>
+                            <th>Phone</th>
+                            <th>Rooms</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var prop in Model.Properties)
+                        {
+                            <tr>
+                                <td class="fw-semibold">@prop.Name</td>
+                                <td>@prop.AgentName</td>
+                                <td>@(prop.AgentPhone ?? "-")</td>
+                                <td><span class="badge bg-secondary">@prop.Rooms.Count rooms</span></td>
+                                <td class="text-end">
+                                    <button class="btn btn-outline-primary btn-sm"
+                                            data-bs-toggle="collapse" data-bs-target="#pedit-@prop.Id">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr class="collapse" id="pedit-@prop.Id">
+                                <td colspan="5" class="bg-light">
+                                    <form method="post" asp-page-handler="EditProperty" class="row g-2 p-2 align-items-end">
+                                        <input type="hidden" asp-for="EditPropertyId" value="@prop.Id" />
+                                        <div class="col-12 col-md-3">
+                                            <input type="text" name="EditPropertyName" value="@prop.Name"
+                                                   class="form-control form-control-sm" placeholder="Property name *" required />
+                                        </div>
+                                        <div class="col-12 col-md-3">
+                                            <input type="text" name="EditPropertyAgent" value="@prop.AgentName"
+                                                   class="form-control form-control-sm" placeholder="Agent name *" required />
+                                        </div>
+                                        <div class="col-12 col-md-2">
+                                            <input type="text" name="EditPropertyPhone" value="@prop.AgentPhone"
+                                                   class="form-control form-control-sm" placeholder="Phone" />
+                                        </div>
+                                        <div class="col-12 col-md-2">
+                                            <input type="text" name="EditPropertyAddress1" value="@prop.AddressLine1"
+                                                   class="form-control form-control-sm" placeholder="Address" />
+                                        </div>
+                                        <div class="col-12 col-md-2">
+                                            <input type="text" name="EditPropertyCity" value="@prop.City"
+                                                   class="form-control form-control-sm" placeholder="City" />
+                                        </div>
+                                        <div class="col-12 d-flex gap-2">
+                                            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+                                            <button type="button" class="btn btn-outline-secondary btn-sm"
+                                                    data-bs-toggle="collapse" data-bs-target="#pedit-@prop.Id">Cancel</button>
+                                        </div>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
     </div>
 </div>
 
+@* ── ROOMS ── *@
 @if (!Model.Rooms.Any())
 {
     <p class="text-muted text-center py-4">No rooms yet. Add one below.</p>
 }
 else
 {
-    @* ── MOBILE: card per room (hidden on md+) ── *@
+    @* ── MOBILE: card per room ── *@
     <div class="d-md-none mb-3">
         @foreach (var room in Model.Rooms)
         {
@@ -99,12 +174,16 @@ else
                                     <span class="badge bg-secondary ms-1">Inactive</span>
                                 }
                             </div>
-                            <div class="small text-muted">@room.TenantName</div>
+                            <div class="text-muted small">@room.TenantName</div>
                             @if (!string.IsNullOrEmpty(room.TenantPhone))
                             {
-                                <div class="small text-muted"><i class="bi bi-telephone"></i> @room.TenantPhone</div>
+                                <div class="text-muted small"><i class="bi bi-telephone"></i> @room.TenantPhone</div>
                             }
                             <div class="small fw-semibold text-primary mt-1">R @room.RentAmount.ToString("N2") / month</div>
+                            @if (room.Property != null)
+                            {
+                                <div class="small text-muted"><i class="bi bi-building"></i> @room.Property.Name</div>
+                            }
                         </div>
                         <div class="d-flex flex-column gap-1 align-items-end">
                             <button class="btn btn-outline-primary btn-sm"
@@ -138,6 +217,15 @@ else
                                 <input type="number" name="EditRentAmount" value="@room.RentAmount"
                                        class="form-control form-control-sm" placeholder="Rent (R)" step="0.01" min="0" required />
                             </div>
+                            <div class="mb-2">
+                                <select name="EditPropertyIdLink" class="form-select form-select-sm">
+                                    <option value="">-- No Property --</option>
+                                    @foreach (var p in Model.Properties)
+                                    {
+                                        <option value="@p.Id" selected="@(room.PropertyId == p.Id)">@p.Name</option>
+                                    }
+                                </select>
+                            </div>
                             <div class="d-flex gap-2">
                                 <button type="submit" class="btn btn-primary btn-sm flex-fill">Save</button>
                                 <button type="button" class="btn btn-outline-secondary btn-sm"
@@ -150,7 +238,7 @@ else
         }
     </div>
 
-    @* ── DESKTOP: table (hidden on mobile) ── *@
+    @* ── DESKTOP: table ── *@
     <div class="d-none d-md-block card mb-4">
         <div class="card-header fw-semibold"><i class="bi bi-list-ul"></i> Rooms</div>
         <div class="card-body p-0">
@@ -159,6 +247,7 @@ else
                     <thead class="table-light">
                         <tr>
                             <th>Room</th>
+                            <th>Property</th>
                             <th>Tenant</th>
                             <th>Phone</th>
                             <th class="text-end">Rent (R)</th>
@@ -171,6 +260,7 @@ else
                         {
                             <tr>
                                 <td class="align-middle fw-semibold">@room.Name</td>
+                                <td class="align-middle text-muted small">@(room.Property?.Name ?? "-")</td>
                                 <td class="align-middle">@room.TenantName</td>
                                 <td class="align-middle">@room.TenantPhone</td>
                                 <td class="align-middle text-end">@room.RentAmount.ToString("N2")</td>
@@ -198,14 +288,14 @@ else
                                 </td>
                             </tr>
                             <tr class="collapse" id="edit-@room.Id">
-                                <td colspan="6" class="bg-light">
+                                <td colspan="7" class="bg-light">
                                     <form method="post" asp-page-handler="Edit" class="row g-2 p-2 align-items-end">
                                         <input type="hidden" asp-for="EditId" value="@room.Id" />
-                                        <div class="col-md-3">
+                                        <div class="col-md-2">
                                             <input type="text" name="EditName" value="@room.Name"
                                                    class="form-control form-control-sm" placeholder="Room Name" required />
                                         </div>
-                                        <div class="col-md-3">
+                                        <div class="col-md-2">
                                             <input type="text" name="EditTenantName" value="@room.TenantName"
                                                    class="form-control form-control-sm" placeholder="Tenant Name" />
                                         </div>
@@ -213,9 +303,18 @@ else
                                             <input type="text" name="EditTenantPhone" value="@room.TenantPhone"
                                                    class="form-control form-control-sm" placeholder="Phone" />
                                         </div>
-                                        <div class="col-md-2">
+                                        <div class="col-md-1">
                                             <input type="number" name="EditRentAmount" value="@room.RentAmount"
                                                    class="form-control form-control-sm" step="0.01" min="0" required />
+                                        </div>
+                                        <div class="col-md-3">
+                                            <select name="EditPropertyIdLink" class="form-select form-select-sm">
+                                                <option value="">-- No Property --</option>
+                                                @foreach (var p in Model.Properties)
+                                                {
+                                                    <option value="@p.Id" selected="@(room.PropertyId == p.Id)">@p.Name</option>
+                                                }
+                                            </select>
                                         </div>
                                         <div class="col-md-2 d-flex gap-2">
                                             <button type="submit" class="btn btn-primary btn-sm">Save</button>
@@ -233,30 +332,41 @@ else
     </div>
 }
 
+@* ── ADD ROOM ── *@
 <div class="card">
     <div class="card-header fw-semibold"><i class="bi bi-plus-circle"></i> Add Room</div>
     <div class="card-body">
         <form method="post" asp-page-handler="Add">
             <div class="row g-3">
                 <div class="col-12 col-md-3">
-                    <label asp-for="NewName" class="form-label">Room Name</label>
+                    <label class="form-label">Room Name</label>
                     <input asp-for="NewName" class="form-control" placeholder="e.g. Cottage 1" required />
                 </div>
-                <div class="col-12 col-md-3">
-                    <label asp-for="NewTenantName" class="form-label">Tenant Name</label>
+                <div class="col-12 col-md-2">
+                    <label class="form-label">Tenant Name</label>
                     <input asp-for="NewTenantName" class="form-control" placeholder="e.g. John Smith" />
                 </div>
                 <div class="col-12 col-md-2">
-                    <label asp-for="NewTenantPhone" class="form-label">Phone</label>
+                    <label class="form-label">Phone</label>
                     <input asp-for="NewTenantPhone" class="form-control" placeholder="082 000 0000" />
                 </div>
                 <div class="col-12 col-md-2">
-                    <label asp-for="NewRentAmount" class="form-label">Rent (R)</label>
+                    <label class="form-label">Rent (R)</label>
                     <input asp-for="NewRentAmount" class="form-control" type="number" step="0.01" min="0" placeholder="0.00" required />
                 </div>
-                <div class="col-12 col-md-2 d-flex align-items-end">
+                <div class="col-12 col-md-2">
+                    <label class="form-label">Property</label>
+                    <select asp-for="NewPropertyIdLink" class="form-select">
+                        <option value="">-- None --</option>
+                        @foreach (var p in Model.Properties)
+                        {
+                            <option value="@p.Id">@p.Name</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-12 col-md-1 d-flex align-items-end">
                     <button type="submit" class="btn btn-primary w-100">
-                        <i class="bi bi-plus-lg"></i> Add Room
+                        <i class="bi bi-plus-lg"></i> Add
                     </button>
                 </div>
             </div>

--- a/InvoiceApp.Web/Pages/Settings/Rooms.cshtml.cs
+++ b/InvoiceApp.Web/Pages/Settings/Rooms.cshtml.cs
@@ -12,73 +12,112 @@ public class RoomsModel : PageModel
 
     public RoomsModel(AppDbContext db) => _db = db;
 
+    public List<Property> Properties { get; set; } = new();
     public List<Room> Rooms { get; set; } = new();
 
-    [BindProperty] public RentSettings Property { get; set; } = new();
+    // Add property
+    [BindProperty] public string NewPropertyName { get; set; } = string.Empty;
+    [BindProperty] public string NewPropertyAgent { get; set; } = string.Empty;
+    [BindProperty] public string? NewPropertyPhone { get; set; }
+    [BindProperty] public string? NewPropertyAddress1 { get; set; }
+    [BindProperty] public string? NewPropertyAddress2 { get; set; }
+    [BindProperty] public string? NewPropertyCity { get; set; }
+    [BindProperty] public string? NewPropertyPostalCode { get; set; }
 
+    // Edit property
+    [BindProperty] public int EditPropertyId { get; set; }
+    [BindProperty] public string EditPropertyName { get; set; } = string.Empty;
+    [BindProperty] public string EditPropertyAgent { get; set; } = string.Empty;
+    [BindProperty] public string? EditPropertyPhone { get; set; }
+    [BindProperty] public string? EditPropertyAddress1 { get; set; }
+    [BindProperty] public string? EditPropertyAddress2 { get; set; }
+    [BindProperty] public string? EditPropertyCity { get; set; }
+    [BindProperty] public string? EditPropertyPostalCode { get; set; }
+
+    // Add room
     [BindProperty] public string NewName { get; set; } = string.Empty;
     [BindProperty] public string NewTenantName { get; set; } = string.Empty;
     [BindProperty] public string NewTenantPhone { get; set; } = string.Empty;
     [BindProperty] public decimal NewRentAmount { get; set; }
+    [BindProperty] public int? NewPropertyIdLink { get; set; }
 
+    // Edit room
     [BindProperty] public int EditId { get; set; }
     [BindProperty] public string EditName { get; set; } = string.Empty;
     [BindProperty] public string EditTenantName { get; set; } = string.Empty;
     [BindProperty] public string EditTenantPhone { get; set; } = string.Empty;
     [BindProperty] public decimal EditRentAmount { get; set; }
+    [BindProperty] public int? EditPropertyIdLink { get; set; }
 
     [TempData] public string? StatusMessage { get; set; }
 
     public async Task OnGetAsync()
     {
-        Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-        Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
+        Properties = await _db.Properties.OrderBy(p => p.Name).ToListAsync();
+        Rooms = await _db.Rooms.Include(r => r.Property).OrderBy(r => r.Name).ToListAsync();
     }
 
-    public async Task<IActionResult> OnPostSavePropertyAsync()
+    public async Task<IActionResult> OnPostAddPropertyAsync()
     {
-        Property.PropertyName = Property.PropertyName?.Trim() ?? string.Empty;
-        Property.AgentName = Property.AgentName?.Trim() ?? string.Empty;
+        NewPropertyName = NewPropertyName?.Trim() ?? string.Empty;
+        NewPropertyAgent = NewPropertyAgent?.Trim() ?? string.Empty;
 
-        if (string.IsNullOrWhiteSpace(Property.PropertyName))
-            ModelState.AddModelError("Property.PropertyName", "Property name is required.");
-
-        if (string.IsNullOrWhiteSpace(Property.AgentName))
-            ModelState.AddModelError("Property.AgentName", "Agent name is required.");
+        if (string.IsNullOrWhiteSpace(NewPropertyName))
+            ModelState.AddModelError("NewPropertyName", "Property name is required.");
+        if (string.IsNullOrWhiteSpace(NewPropertyAgent))
+            ModelState.AddModelError("NewPropertyAgent", "Agent name is required.");
 
         if (!ModelState.IsValid)
         {
-            Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
+            Properties = await _db.Properties.OrderBy(p => p.Name).ToListAsync();
+            Rooms = await _db.Rooms.Include(r => r.Property).OrderBy(r => r.Name).ToListAsync();
             return Page();
         }
 
-        var existing = await _db.RentSettings.FirstOrDefaultAsync();
-        if (existing == null)
+        _db.Properties.Add(new Property
         {
-            _db.RentSettings.Add(new RentSettings
-            {
-                PropertyName = Property.PropertyName,
-                AgentName = Property.AgentName,
-                AgentPhone = Property.AgentPhone?.Trim(),
-                AddressLine1 = Property.AddressLine1?.Trim(),
-                AddressLine2 = Property.AddressLine2?.Trim(),
-                City = Property.City?.Trim(),
-                PostalCode = Property.PostalCode?.Trim()
-            });
-        }
-        else
+            Name = NewPropertyName,
+            AgentName = NewPropertyAgent,
+            AgentPhone = NewPropertyPhone?.Trim(),
+            AddressLine1 = NewPropertyAddress1?.Trim(),
+            AddressLine2 = NewPropertyAddress2?.Trim(),
+            City = NewPropertyCity?.Trim(),
+            PostalCode = NewPropertyPostalCode?.Trim()
+        });
+        await _db.SaveChangesAsync();
+        TempData["StatusMessage"] = "Property added.";
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostEditPropertyAsync()
+    {
+        var property = await _db.Properties.FindAsync(EditPropertyId);
+        if (property == null) return NotFound();
+
+        EditPropertyName = EditPropertyName?.Trim() ?? string.Empty;
+        EditPropertyAgent = EditPropertyAgent?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(EditPropertyName))
+            ModelState.AddModelError("EditPropertyName", "Property name is required.");
+        if (string.IsNullOrWhiteSpace(EditPropertyAgent))
+            ModelState.AddModelError("EditPropertyAgent", "Agent name is required.");
+
+        if (!ModelState.IsValid)
         {
-            existing.PropertyName = Property.PropertyName;
-            existing.AgentName = Property.AgentName;
-            existing.AgentPhone = Property.AgentPhone?.Trim();
-            existing.AddressLine1 = Property.AddressLine1?.Trim();
-            existing.AddressLine2 = Property.AddressLine2?.Trim();
-            existing.City = Property.City?.Trim();
-            existing.PostalCode = Property.PostalCode?.Trim();
+            Properties = await _db.Properties.OrderBy(p => p.Name).ToListAsync();
+            Rooms = await _db.Rooms.Include(r => r.Property).OrderBy(r => r.Name).ToListAsync();
+            return Page();
         }
 
+        property.Name = EditPropertyName;
+        property.AgentName = EditPropertyAgent;
+        property.AgentPhone = EditPropertyPhone?.Trim();
+        property.AddressLine1 = EditPropertyAddress1?.Trim();
+        property.AddressLine2 = EditPropertyAddress2?.Trim();
+        property.City = EditPropertyCity?.Trim();
+        property.PostalCode = EditPropertyPostalCode?.Trim();
         await _db.SaveChangesAsync();
-        TempData["StatusMessage"] = "Property settings saved.";
+        TempData["StatusMessage"] = "Property updated.";
         return RedirectToPage();
     }
 
@@ -90,14 +129,13 @@ public class RoomsModel : PageModel
 
         if (string.IsNullOrWhiteSpace(NewName))
             ModelState.AddModelError("NewName", "Room name is required.");
-
         if (NewRentAmount < 0)
             ModelState.AddModelError("NewRentAmount", "Rent amount cannot be negative.");
 
         if (!ModelState.IsValid)
         {
-            Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-            Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
+            Properties = await _db.Properties.OrderBy(p => p.Name).ToListAsync();
+            Rooms = await _db.Rooms.Include(r => r.Property).OrderBy(r => r.Name).ToListAsync();
             return Page();
         }
 
@@ -107,7 +145,8 @@ public class RoomsModel : PageModel
             TenantName = NewTenantName,
             TenantPhone = NewTenantPhone,
             RentAmount = NewRentAmount,
-            IsActive = true
+            IsActive = true,
+            PropertyId = NewPropertyIdLink
         });
         await _db.SaveChangesAsync();
         TempData["StatusMessage"] = "Room added.";
@@ -125,14 +164,13 @@ public class RoomsModel : PageModel
 
         if (string.IsNullOrWhiteSpace(EditName))
             ModelState.AddModelError("EditName", "Room name is required.");
-
         if (EditRentAmount < 0)
             ModelState.AddModelError("EditRentAmount", "Rent amount cannot be negative.");
 
         if (!ModelState.IsValid)
         {
-            Rooms = await _db.Rooms.OrderBy(r => r.Name).ToListAsync();
-            Property = await _db.RentSettings.FirstOrDefaultAsync() ?? new RentSettings();
+            Properties = await _db.Properties.OrderBy(p => p.Name).ToListAsync();
+            Rooms = await _db.Rooms.Include(r => r.Property).OrderBy(r => r.Name).ToListAsync();
             return Page();
         }
 
@@ -140,6 +178,7 @@ public class RoomsModel : PageModel
         room.TenantName = EditTenantName;
         room.TenantPhone = EditTenantPhone;
         room.RentAmount = EditRentAmount;
+        room.PropertyId = EditPropertyIdLink;
         await _db.SaveChangesAsync();
         TempData["StatusMessage"] = "Room updated.";
         return RedirectToPage();


### PR DESCRIPTION
## Summary

- `RentSettings` (single-row global table) removed — wrong design for a multi-property landlord
- New `Property` entity: Name, AgentName, AgentPhone, Address
- `Room.PropertyId` nullable FK → `Property` (many rooms per property, `SetNull` on delete)
- Receipt FROM section now reads from `room.Property` automatically — no manual re-entry
- `Settings > Rooms` page redesigned: create/manage properties first, then link rooms via dropdown
- `RentReceiptPdfService.Generate(payment, banking)` — reads `payment.Room.Property` directly

## Migration
`AddPropertyAndLinkRooms`: drops `RentSettings` table, creates `Property` table, adds nullable `PropertyId` FK to `Room`

## Tests
6 new tests in `PropertyTests.cs`:
- Property created and retrieved
- Room linked to property
- Room with no property (nullable FK)
- Multiple rooms per property
- PDF generates correctly with property linked
- PDF generates gracefully with no property linked

**46/46 tests passing**

## How to use
1. Settings > Rooms → Add a Property (name + agent)
2. Add/Edit a Room → select the Property from dropdown
3. Mark room as paid → Print/Download receipt → FROM shows property name and agent

Generated with [Claude Code](https://claude.ai/claude-code)