### PR TITLE
fix(ci): make maintenance-mode FTP step tolerant of FTP_SERVER format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,12 @@ jobs:
           echo "Deployment files prepared"
 
       - name: Put site in maintenance mode
+        continue-on-error: true
         run: |
+          # FTP_SERVER may carry a scheme or stray whitespace that the FTP-Deploy
+          # action tolerates but curl rejects ("URL using bad/illegal format").
+          FTP_HOST="$(printf '%s' "${{ secrets.FTP_SERVER }}" | tr -d '[:space:]' | sed -E 's#^ftps?://##')"
+
           cat << 'EOF' > app_offline.htm
           <!doctype html>
           <html>
@@ -104,7 +109,7 @@ jobs:
           curl --fail --ftp-create-dirs \
             -T ./app_offline.htm \
             --user "${{ secrets.FTP_USERNAME }}:${{ secrets.FTP_PASSWORD }}" \
-            "ftp://${{ secrets.FTP_SERVER }}/blacktech.gcweproperty.co.za/wwwroot/app_offline.htm"
+            "ftp://${FTP_HOST}/blacktech.gcweproperty.co.za/wwwroot/app_offline.htm"
 
       - name: Deploy to FTP server
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
@@ -122,10 +127,12 @@ jobs:
 
       - name: Remove maintenance mode file
         if: always()
+        continue-on-error: true
         run: |
+          FTP_HOST="$(printf '%s' "${{ secrets.FTP_SERVER }}" | tr -d '[:space:]' | sed -E 's#^ftps?://##')"
           curl --fail --user "${{ secrets.FTP_USERNAME }}:${{ secrets.FTP_PASSWORD }}" \
             --quote "DELE /blacktech.gcweproperty.co.za/wwwroot/app_offline.htm" \
-            "ftp://${{ secrets.FTP_SERVER }}/"
+            "ftp://${FTP_HOST}/"
 
       - name: Deployment Summary
         run: |


### PR DESCRIPTION
The deploy run on master failed at "Put site in maintenance mode" with "curl: (3) URL using bad/illegal format or missing URL": the FTP_SERVER secret carries a scheme/whitespace that the FTP-Deploy action tolerates but curl does not.

- Sanitize FTP_SERVER (strip ftp(s):// scheme and whitespace) before building the curl URL, in both the upload and DELE steps.
- Mark both maintenance steps continue-on-error so failing to toggle the offline page never blocks the actual deploy.